### PR TITLE
Add OCaml Tuareg mode to exceptions

### DIFF
--- a/emojify.el
+++ b/emojify.el
@@ -244,7 +244,8 @@ Possible values are
     compilation-mode
     proced-mode
     comint-mode
-    mu4e-headers-mode)
+    mu4e-headers-mode
+    tuareg-mode)
   "Major modes where emojify mode should not be enabled."
   :type '(repeat symbol)
   :group 'emojify)


### PR DESCRIPTION
OCaml comments read as `(* Some comment *)`. But the `*)`
translates to :wink:, which is not intended.