### PR TITLE
Makes comint derived modes act like prog derived

### DIFF
--- a/emojify.el
+++ b/emojify.el
@@ -263,7 +263,6 @@ Possible values are
     ert-results-mode
     compilation-mode
     proced-mode
-    comint-mode
     mu4e-headers-mode)
   "Major modes where emojify mode should not be enabled."
   :type '(repeat symbol)
@@ -810,7 +809,7 @@ TODO: Skip emojifying if region is already emojified."
             (when (and (memql (intern (ht-get emoji "style"))
                               emojify-emoji-styles)
                        ;; Display unconditionally in non-prog mode
-                       (or (not (derived-mode-p 'prog-mode 'tuareg--prog-mode))
+                       (or (not (derived-mode-p 'prog-mode 'tuareg--prog-mode 'comint-mode))
                            ;; In prog mode enable respecting `emojify-program-contexts'
                            (emojify-valid-program-context-p emoji match-beginning match-end))
 


### PR DESCRIPTION
Makes comint-mode derived modes act as if they are prog-mode
derived. This means instead of having emojify disabled by default in
these modes, unicode emojis are emojified and whatever rules the user
has set for programming based rules applies to these modes as
well. Since comint mode is described as being for a
"command-interpreter-in-a-buffer" which is essentially a repl, it makes
sense to treat it as a programming mode. This would allow shell-mode to
be able to display emoji in a (hopefully) sensible way.
