### PR TITLE
Do not scale created images

### DIFF
--- a/emojify.el
+++ b/emojify.el
@@ -965,6 +965,7 @@ other different display constructs, for now this works."
                                          (face-background 'mode-line nil 'default))
                                         (t (emojify--get-image-background beg end)))
                       ;; no-op if imagemagick is  not available
+                      :scale 1
                       :height (cond ((bufferp target)
                                      (with-current-buffer target
                                        (emojify-default-font-height)))


### PR DESCRIPTION
Starting from Emacs 26.1, images are automatically scaled to match the
frame DPI value (HiDPI support), unless `image-scaling-factor' is set
to a value different than auto. However, the height of the emoji
images is computed from the height of the current font. Therefore,
there is no need to scale them. Therefore, we enforce a scale of 1.