### PR TITLE
add emojify-mode-map

### DIFF
--- a/emojify.el
+++ b/emojify.el
@@ -1548,9 +1548,16 @@ run the command `emojify-download-emoji'")))
   ;; Remove style change hooks
   (remove-hook 'emojify-emoji-style-change-hook #'emojify-redisplay-emojis-in-region))
 
+;; define a emojify-mode-map to enable defining keys specifically for emojify-mode
+(defvar emojify-mode-map
+  (let ((map (make-sparse-keymap)))
+    map)
+  "Keymap for `emojify-mode'.")
+
 ;;;###autoload
 (define-minor-mode emojify-mode
   "Emojify mode"
+  :keymap emojify-mode-map
   :init-value nil
   (if emojify-mode
       ;; Turn on


### PR DESCRIPTION
To enable defining keys only when emojify mode is enabled I think a variable emojify-mode map should be added to the emojify-minor-mode