### PR TITLE
Add GitHub Actions setting file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs-version:
+          - emacs-26.2
+          - emacs-26.1
+          - emacs-25.3
+          - emacs-25.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/emacsen
+            ~/.emacs.d/emojis
+          key: ${{ runner.os }}-${{ matrix.emacs-version }}-${{ hashFiles('**/Cask') }}
+
+      - name: Install dependencies
+        run: sudo apt-get install libxaw7-dev libgnutls28-dev
+
+      - name: Install EVM
+        run: |
+          curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+          echo "$HOME/.evm/bin" >> $GITHUB_PATH
+
+      - name: SetUp EVM
+        run: |
+          mkdir -p $HOME/emacsen
+          evm config path $HOME/emacsen
+          evm install ${{ matrix.emacs-version }} --skip
+          evm use ${{ matrix.emacs-version }}
+
+      - name: Install Cask
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python3
+          echo "$HOME/.cask/bin:$PATH" >> $GITHUB_PATH
+
+      - name: Install
+        run: cask install
+
+      - name: Run tests
+        run: find . -name '*.elc' -delete && cask exec ert-runner


### PR DESCRIPTION
- [travis-ci.**org**](https://travis-ci.com) is sunsetting 😢 
    - > Please be aware travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com. Please stay tuned here for more information. 
- [travis-ci.**com**](https://travis-ci.com) has been required an application to use their resource unlimitedly even though we are OSS works
    - https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
    - > We will be offering an allotment of OSS minutes that will be reviewed and allocated on a case by case basis. Should you want to apply for these credits please open a request with Travis CI support stating that you’d like to be considered for the OSS allotment
- So I try to move to GitHub Actions as a new CI
- Example result: https://github.com/y-yu/emacs-emojify/actions/runs/626993649
- First I tried to use [`actions/set-up-emacs`](https://github.com/marketplace/actions/set-up-emacs) and [`actions/setup-cask`](https://github.com/marketplace/actions/setup-cask)
    - But `actions/set-up-emacs` does not support `png`, `jpeg` and so on
        - https://github.com/purcell/nix-emacs-ci/blob/61c5c50b44b11b2b339b9d4474bf67db32b325d4/emacs.nix#L51-L61
    - That's the why I don't use these actions