### PR TITLE
Make terminal modes act like prog derived

### DIFF
--- a/emojify.el
+++ b/emojify.el
@@ -1154,7 +1154,8 @@ should not be a problem 🤞."
                                                       major-mode)))
                            ;; Display unconditionally in non-prog mode
                            (or (not (emojify-provided-mode-derived-p major-mode-at-point
-                                                                     'prog-mode 'tuareg--prog-mode 'comint-mode 'smalltalk-mode))
+                                                                     'prog-mode 'tuareg--prog-mode 'comint-mode
+                                                                     'smalltalk-mode 'vterm-mode 'term-mode 'eshell-mode))
                                ;; In prog mode enable respecting `emojify-program-contexts'
                                (emojify-valid-program-context-p emoji
                                                                 match-beginning


### PR DESCRIPTION
Similar like 361e605266db9654e09bb9fee7ea56f865be418ebut but for
vterm, eshell and term related modes.